### PR TITLE
Use checkout v3 in GH actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   tox_test:
     name: Tox test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run Tox tests
       id: test
       uses: fedora-python/tox-github-action@master


### PR DESCRIPTION
Addressing:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/