### PR TITLE
tests: compat with flask-sqlalchemy v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 name: Run Tox tests
 
@@ -20,7 +20,7 @@ jobs:
         tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        tox_env: [py36, py37, py38, py39, py310]
+        tox_env: [py36, py37, py38, py39, py310, py311]
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,23 @@
+---
+specfile_path: fedora/python-flask-whooshee.spec
+
+actions:
+  create-archive:
+    - python3 setup.py sdist --dist-dir ./fedora/
+    - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
+  get-current-version: "sed -n \"s|.*version='\\(.*\\)'.*|\\1|p\" setup.py"
+
+jobs:
+  - &copr
+    job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-all
+
+  - <<: *copr
+    trigger: commit
+    metadata:
+      owner: "@copr"
+      project: "flask-whooshee-prerelease"
+      branch: main

--- a/fedora/python-flask-whooshee.spec
+++ b/fedora/python-flask-whooshee.spec
@@ -1,0 +1,64 @@
+%global mod_name flask-whooshee
+
+Name:           python-flask-whooshee
+Version:        0
+Release:        1%{?dist}
+Summary:        Whoosh integration
+
+License:        GPLv2+
+URL:            https://github.com/bkabrda/flask-whooshee
+Source0:        https://pypi.python.org/packages/source/f/%{mod_name}/%{mod_name}-%{version}.tar.gz
+# https://github.com/bkabrda/flask-whooshee/pull/19
+BuildArch:      noarch
+
+
+%global _description \
+Whoosh integration that allows to create and search custom indexes.
+
+%description %{_description}
+
+%package -n python3-%{mod_name}
+Summary:        Whoosh integration
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-whoosh
+BuildRequires:  python3-flask
+BuildRequires:  python3-flask-sqlalchemy
+BuildRequires:  python3-flexmock
+BuildRequires:  python3-blinker
+BuildRequires:  python3-nose
+BuildRequires:  python3-pytest
+
+Requires:       python3-flask-sqlalchemy
+Requires:       python3-whoosh
+Requires:       python3-blinker
+Requires:       python3-flask
+
+%description -n python3-%{mod_name} %{_description}
+
+Python 3 version.
+
+%prep
+%autosetup -n %{mod_name}-%{version}
+
+%build
+%py3_build
+
+%check
+%{__python3} -m pytest -vv test.py
+
+
+%install
+%py3_install
+
+
+%files -n python3-%{mod_name}
+%doc LICENSE README.md
+%{python3_sitelib}/__pycache__/*
+%{python3_sitelib}/*.egg-info
+%{python3_sitelib}/flask_whooshee.py
+
+
+%changelog
+* Wed Apr 05 2023 Pavel Raiskup <praiskup@redhat.com> - 0-1
+- no %%changelog for the git main branch

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -126,11 +126,11 @@ class WhoosheeQuery(BaseQuery):
 
         if order_by_relevance < 0: # we want all returned rows ordered
             search_query = search_query.order_by(sqlalchemy.sql.expression.case(
-                [(attr == uniq_val, index) for index, uniq_val in enumerate(res)],
+                *[(attr == uniq_val, index) for index, uniq_val in enumerate(res)],
             ))
         elif order_by_relevance > 0: # we want only number of specified rows ordered
             search_query = search_query.order_by(sqlalchemy.sql.expression.case(
-                [(attr == uniq_val, index) for index, uniq_val in enumerate(res) if index < order_by_relevance],
+                *[(attr == uniq_val, index) for index, uniq_val in enumerate(res) if index < order_by_relevance],
                 else_=order_by_relevance
             ))
         else: # no ordering

--- a/test.py
+++ b/test.py
@@ -11,6 +11,7 @@ from whoosh.filedb.filestore import RamStorage
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy, BaseQuery
 from sqlalchemy.orm import Query as SQLAQuery
+from sqlalchemy.sql import text
 from flask_whooshee import AbstractWhoosheer, Whooshee, WhoosheeQuery
 
 
@@ -267,7 +268,7 @@ class BaseTestCases(object):
             # generall reindex
             self.wh.reindex()
             # put stallone directly in db and find him only after reindex
-            result = self.db.session.execute("INSERT INTO entry VALUES (100, 'rambo', 'pack of one two and three', {0})".format(self.u3.id))
+            result = self.db.session.execute(text("INSERT INTO entry VALUES (100, 'rambo', 'pack of one two and three', {0})".format(self.u3.id)))
             self.db.session.commit()
             found = self.Entry.query.join(self.User).whooshee_search('rambo').all()
             self.assertEqual(len(found), 0)


### PR DESCRIPTION
The 'create_all()' and 'drop_all()' methods no longer have the 'app=' argument.  Therefore we have to use 'with app.app_context()' wrapper, at least when there are multiple apps in action.

Otherwise, it is possible to take the app context on a per-test-case basis, using the pattern:

    setUp():
        self.ctx = self.app.app_context()
        self.ctx.push()

    tearDown():
        self.ctx.pop()

The changes done in this commit still keep compatibility with flask-sqlalchemy v2.

Fixes: #75
Closes: #74
Closes: #73
Closes: #78