### PR TITLE
Stop using deprecated BaseQuery

### DIFF
--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -15,7 +15,10 @@ import whoosh.qparser
 from whoosh.filedb.filestore import RamStorage
 
 from flask import current_app
-from flask_sqlalchemy.query import Query
+try:
+    from flask_sqlalchemy.query import Query
+except ImportError:
+    from flask_sqlalchemy import BaseQuery as Query
 from sqlalchemy import text, event
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.mapper import Mapper

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -15,7 +15,7 @@ import whoosh.qparser
 from whoosh.filedb.filestore import RamStorage
 
 from flask import current_app
-from flask_sqlalchemy import BaseQuery
+from flask_sqlalchemy.query import Query
 from sqlalchemy import text, event
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.mapper import Mapper
@@ -48,7 +48,7 @@ def _assure_dirs_exists(path):
         if err.errno != errno.EEXIST:
             raise
 
-class WhoosheeQuery(BaseQuery):
+class WhoosheeQuery(Query):
     """An override for SQLAlchemy query used to do fulltext search."""
 
     def whooshee_search(self, search_string, group=whoosh.qparser.OrGroup, whoosheer=None,
@@ -293,7 +293,7 @@ class Whooshee(object):
                     pass
 
                 # ensure there can be a stable MRO
-                elif query_class not in (BaseQuery, SQLAQuery, WhoosheeQuery):
+                elif query_class not in (Query, SQLAQuery, WhoosheeQuery):
                     query_class_name = query_class.__name__
                     model.query_class = type(
                         "Whooshee{}".format(query_class_name), (query_class, self.query), {}

--- a/test.py
+++ b/test.py
@@ -10,7 +10,10 @@ import whoosh
 from whoosh.filedb.filestore import RamStorage
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from flask_sqlalchemy.query import Query
+try:
+    from flask_sqlalchemy.query import Query
+except ImportError:
+    from flask_sqlalchemy import BaseQuery as Query
 from sqlalchemy.orm import Query as SQLAQuery
 from flask_whooshee import AbstractWhoosheer, Whooshee, WhoosheeQuery
 

--- a/test.py
+++ b/test.py
@@ -9,7 +9,8 @@ from flexmock import flexmock
 import whoosh
 from whoosh.filedb.filestore import RamStorage
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy, BaseQuery
+from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.query import Query
 from sqlalchemy.orm import Query as SQLAQuery
 from flask_whooshee import AbstractWhoosheer, Whooshee, WhoosheeQuery
 
@@ -712,14 +713,14 @@ class TestDoesntMixesWithModelQueryClass(TestCase):
         self.wh = Whooshee(self.app)
 
     def test_mixes_with_model_query(self):
-        class CustomQueryClass(BaseQuery):
+        class CustomQueryClass(Query):
             pass
 
         self._make_model_and_whoosheer(CustomQueryClass)
         self.assertEqual('WhoosheeCustomQueryClass', self.user_model.query_class.__name__)
 
     def test_doesnt_mix_with_default_query_class(self):
-        self._make_model_and_whoosheer(BaseQuery)
+        self._make_model_and_whoosheer(Query)
         self.assertIs(self.wh.query, self.user_model.query_class)
 
     def test_doesnt_mix_with_explicit_whooshee_query_class(self):


### PR DESCRIPTION
Fix #84

    >>> from flask_sqlalchemy import BaseQuery
    DeprecationWarning: 'BaseQuery' has been moved and renamed to
    'query.Query'. The top-level import is deprecated and will be
    removed in Flask-SQLAlchemy 3.1.